### PR TITLE
Intelligently handle document-local links

### DIFF
--- a/modules/common.jsm
+++ b/modules/common.jsm
@@ -933,6 +933,10 @@ var sbCommonUtils = {
         }
         return aObject1;
     },
+
+    isFunction : function(arg) {
+        return Object.prototype.toString.call(arg) === '[object Function]';
+    }
 };
 
 /**


### PR DESCRIPTION
Rework of #87

* detectLocalHref is inlined
* sbCommonUtils.splitURLByAnchor instead of low-level string manipulation
* Avoid exceptions if Selector API is unavailable.

I have faced a site with links in the form of
``` html
<a href="/path/to/the/dir/#par">paragraph</a>
```
even if their targets are in the same document.
As a result the links in the captured page are not document-local
any more and lead to the original site.

I hope the following changes allow to work with the saved page.

Rewrite href attributes of "a" elements if their targets is within
the captured fragment but they are referenced by full path
or even by full URI.

Make local links work in the captured document even if hash
sign is in the middle of the href attribute.

In the case of page fragment capture, distinguish link targets
within the selection and outside of it.

Caveats:
* In the case of partial capture deep in the nested
page structure, the links to ancestors are considered local
however ancestors content is not included.
* Obsolete <A name="bla-bla-bla"> anchors are not handled
* In the case of page fragment selection and a really old firefox
  version (Selector API is not supported) all links are rewritten
  to the original URI.